### PR TITLE
Fix Angular index template path

### DIFF
--- a/morf/settings.py
+++ b/morf/settings.py
@@ -66,7 +66,9 @@ ROOT_URLCONF = 'morf.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, "public"),
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
## Summary
- ensure Django templates load from the `public` folder

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685939687b8083248c16a6c0573574e7